### PR TITLE
More robust version parsing

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: 'ansibleguy'
 name: 'nftables'
-version: 1.0.0
+version: 1.0.1
 readme: 'README.md'
 authors:
   - 'AnsibleGuy <guy@ansibleguy.net>'

--- a/plugins/module_utils/check.py
+++ b/plugins/module_utils/check.py
@@ -15,7 +15,11 @@ def _check_nft_version() -> bool:
             result = process(cmd=['nft', '--version'])
 
             for part in result['stdout'].split(' '):
-                _v = version.parse(part)
+                try:
+                    _v = version.parse(part)
+                except version.InvalidVersion:
+                    # version.parse throw exceptions if part is not parsable as a version
+                    _v = None 
                 if isinstance(_v, version.Version):
                     nft_version = _v
                     break


### PR DESCRIPTION
Currently version parsing crashes on some systems depending on the format `nft --version` prints to stdout.

This is reported as part of https://github.com/ansibleguy/collection_nftables/issues/1.  I have also confirmed this occurs on Alpine Linux v3.18 (discovered while working in an LXC container) as well as on Devuan GNU/Linux 5 (daedalus) (verified on my laptop).

The underlying issue is that `version.parse` raises a `version.InvalidVersion` exception whenever the string is not a parsable version as per https://packaging.pypa.io/en/stable/version.html#packaging.version.parse.

I suggest solving this using a simple try-except.  If a part of standard out version cannot be parsed (and so throws the error), it will continue on to the next part until it finds a part that can be parsed.  This is more robust that the solution suggested in the Issues post, since it will continue to work as long as at least one component of standard out can be parsed (rather than the suggested solution which would break if `nftables --version` added any string other then "nftables" in front of the version string).